### PR TITLE
Allow router to be used as middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.1.0 - 2018-11-06
+
+### Added
+
+- Router implements PSR-15 `MiddlewareInterface`
+
 ## 1.0.0 - 2018-11-06
 
 - First stable release

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ composer require northwoods/router
 
 ## Usage
 
+The router implements both `MiddlewareInterface` and `RequestHandlerInterface`
+and can be used with any middleware dispatcher, such as [Broker][broker]:
+
 ```php
 use Northwoods\Router\Router;
 use Psr\Http\Message\ResponseInterface;
@@ -32,32 +35,23 @@ $router->get('user.list', '/users', $userList);
 $router->get('user.detail', '/users/{id:\d+}', $userDetail);
 $router->post('user.create', '/users', $userCreate);
 
+assert($router instanceof Psr\Http\Server\MiddlewareInterface);
+```
+
+This is the preferred usage of the router, as it ensures that the request is
+properly set up for the route handler. Generally the router should be the last
+middleware in the stack.
+
+If you prefer to use the router without middleware, the router also implements
+`RequestHandlerInterface` and can be used directly:
+
+```php
 /** @var ServerRequestInterface */
 $request = /* create server request */;
 
 /** @var ResponseInterface */
 $response = $router->handle($request);
 ```
-
-### Usage with Middleware
-
-The router implements `RequestHandlerInterface` and can be used with any
-`MiddlewareInterface` implementation, including middleware dispatchers that
-implement the middleware interface, such as [Broker][broker]:
-
-```php
-/** @var \Northwoods\Broker\Broker */
-$broker = /* create the broker */;
-
-/** @var \Northwoods\Router\Router */
-$router = /* create the router */;
-
-// Use the router as the request handler
-$response = $broker->process($request, $router);
-```
-
-This is the preferred usage of the router, as it ensures that middleware wraps
-the execution of application code.
 
 [broker]: https://github.com/northwoods/broker
 
@@ -141,6 +135,12 @@ Add a route that works for HTTP HEAD requests.
 ### Router::options($name, $pattern, $handler)
 
 Add a route that works for HTTP OPTIONS requests.
+
+### Router::process($request, $handler)
+
+Dispatch routing as a middleware.
+
+If no route is found, the `$handler` will be used to generate the response.
 
 ### Router::handle($request)
 

--- a/src/NotFoundHandler.php
+++ b/src/NotFoundHandler.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Northwoods\Router;
+
+use Fig\Http\Message\StatusCodeInterface;
+use Http\Factory\Discovery\HttpFactory;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class NotFoundHandler implements RequestHandlerInterface
+{
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+
+    public function __construct(
+        ?ResponseFactoryInterface $responseFactory = null
+    ) {
+        $this->responseFactory = $responseFactory ?? HttpFactory::responseFactory();
+    }
+
+    // RequestHandlerInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->responseFactory->createResponse(StatusCodeInterface::STATUS_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Typically the router should be used as *middleware* not a request handler.